### PR TITLE
bump toolchain version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,5 @@ jobs:
       skip-test: ${{ github.event_name == 'push' && 'true' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
       publish: ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish)) && 'true' || 'false' }}
       publish_public_registry: true
+      toolchain: "1.70"
     secrets: inherit


### PR DESCRIPTION
This is in preparation for migrating to bevy 0.11 since it needs rust 1.70